### PR TITLE
Bugfix: Calculation of next date when date is start of year

### DIFF
--- a/Sources/CustomRepeatDate/CustomRepeatDate.swift
+++ b/Sources/CustomRepeatDate/CustomRepeatDate.swift
@@ -261,7 +261,7 @@ public extension Calendar {
                     afterDateComponents.day = day
 
                     // Set the start of the day -1s to be able to include the start of the year
-                    let startingAfter = startOfDay(for: startOfYear(for: afterDate))
+                    let startingAfter = startOfDay(for: startOfYear(for: afterDate)).addingTimeInterval(-1)
                     enumerateDates(
                         startingAfter: startingAfter,
                         matching: afterDateComponents,

--- a/Tests/CustomRepeatDateTests/CustomRepeatDateTests.swift
+++ b/Tests/CustomRepeatDateTests/CustomRepeatDateTests.swift
@@ -388,6 +388,38 @@ final class CustomRepeatDateTests: XCTestCase {
         XCTAssertEqual(repeat5, date(year: 2034, month: 6, day: 12))
     }
 
+    func testYearlyCustomRepeatDateDaysOfYearIsStartOfYear() {
+        let option = CustomRepeatDateOption.yearly(frequency: 1, option: .daysOfYear(months: [1]))
+
+        let repeat1 = calendar.nextDate(after: date(year: 2022, month: 1, day: 1), option: option)!
+        let repeat2 = calendar.nextDate(after: repeat1, option: option)!
+        let repeat3 = calendar.nextDate(after: repeat2, option: option)!
+        let repeat4 = calendar.nextDate(after: repeat3, option: option)!
+        let repeat5 = calendar.nextDate(after: repeat4, option: option)!
+
+        XCTAssertEqual(repeat1, date(year: 2023, month: 1, day: 1))
+        XCTAssertEqual(repeat2, date(year: 2024, month: 1, day: 1))
+        XCTAssertEqual(repeat3, date(year: 2025, month: 1, day: 1))
+        XCTAssertEqual(repeat4, date(year: 2026, month: 1, day: 1))
+        XCTAssertEqual(repeat5, date(year: 2027, month: 1, day: 1))
+    }
+
+    func testYearlyCustomRepeatDateDaysOfYearIsEndOfYear() {
+        let option = CustomRepeatDateOption.yearly(frequency: 1, option: .daysOfYear(months: [12]))
+
+        let repeat1 = calendar.nextDate(after: date(year: 2022, month: 12, day: 31), option: option)!
+        let repeat2 = calendar.nextDate(after: repeat1, option: option)!
+        let repeat3 = calendar.nextDate(after: repeat2, option: option)!
+        let repeat4 = calendar.nextDate(after: repeat3, option: option)!
+        let repeat5 = calendar.nextDate(after: repeat4, option: option)!
+        
+        XCTAssertEqual(repeat1, date(year: 2023, month: 12, day: 31))
+        XCTAssertEqual(repeat2, date(year: 2024, month: 12, day: 31))
+        XCTAssertEqual(repeat3, date(year: 2025, month: 12, day: 31))
+        XCTAssertEqual(repeat4, date(year: 2026, month: 12, day: 31))
+        XCTAssertEqual(repeat5, date(year: 2027, month: 12, day: 31))
+    }
+
     func testYearlyCustomRepeatDateDaysOfYearWithSkippingCases() {
         let option = CustomRepeatDateOption.yearly(frequency: 3, option: .daysOfYear(months: [1, 4]))
 


### PR DESCRIPTION
Hi @pixyzehn,

first of all, thank you for all your hard work on this library! It's really great and I've enjoyed using it in my projects.

However, while working with the library, I came across a small bug: When using a date like January 1st for the yearly recurrence, the calculation would incorrectly skip a year. After investigating, I found that the problem was caused by a missing `.addingTimeInterval(-1)` adjustment.

This pull request resolves this issue by ensuring that the recurrence logic handles this case as expected. In addition, I've added some unit tests to verify the fix and prevent regressions in the future.

Thank you for considering this fix!

Best regards,
Fabian